### PR TITLE
fix(build): Node 22+ OpenSSL 兼容 + .nuxt 产物完整

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,6 @@ CLAUDE.md
 .eslintrc*
 .prettierrc*
 .stylelintrc*
-jsconfig.json
 .eslintcache
 
 logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ RUN npm ci --no-audit --no-fund
 # ---------- Build stage ----------
 FROM node:24-alpine AS builder
 WORKDIR /app
+# Nuxt 2 用的 webpack 4 在 Node 17+ 默认 OpenSSL 3 下会报
+# ERR_OSSL_EVP_UNSUPPORTED（MD4 hash），需要 legacy provider
+ENV NODE_OPTIONS=--openssl-legacy-provider
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-# nuxt.config.ts 里有 tsc nuxt.config.ts && nuxt build
+# 跑 nuxt build；nuxt.config.ts 由 Nuxt 自己的 typescript-build 链处理，不需要单独 tsc
 RUN npm run build && npm prune --omit=dev
 
 # ---------- Runner stage ----------

--- a/deploy.sh
+++ b/deploy.sh
@@ -94,7 +94,8 @@ cmd_install() {
   log "安装依赖..."
   npm ci --no-audit --no-fund
   log "构建..."
-  npm run build
+  # Node 22+ 默认 OpenSSL 3 + webpack 4 不兼容，需要 legacy provider
+  NODE_OPTIONS=--openssl-legacy-provider npm run build
   ok "构建完成（.nuxt/ 已就绪）"
 }
 
@@ -110,7 +111,7 @@ cmd_start() {
   fi
   if [[ ! -d .nuxt ]]; then
     warn ".nuxt 不存在，先跑 build"
-    npm run build
+    NODE_OPTIONS=--openssl-legacy-provider npm run build
   fi
   load_env
 
@@ -118,7 +119,9 @@ cmd_start() {
 
   log "启动 ladis-site（端口 ${PORT:-80}，NAME=${NAME:-未设置}）..."
   # setsid 脱离当前会话，nohup 免疫 SIGHUP，重定向到日志
+  # NODE_OPTIONS 透传给 nuxt 运行时（防止 fork-ts-checker 等子进程报 SSL 错）
   PORT="${PORT:-80}" HOST="${HOST:-0.0.0.0}" NODE_ENV=production \
+    NODE_OPTIONS=--openssl-legacy-provider \
     setsid nohup node node_modules/nuxt/bin/nuxt.js start \
       > "$LOG_FILE" 2>&1 < /dev/null &
   local pid=$!

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "readme": "docker run -itd --restart always --name ladissite -p 80:80 -e NAME='湖北雷迪司' wgcairui/ladissite:latest",
   "scripts": {
     "dev": "cross-env NAME='湖北雷迪司' HOST='localhost' nuxt",
-    "build": "tsc nuxt.config.ts && nuxt build",
+    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider nuxt build",
     "build:docker": "docker build -t ladissite .",
     "generate": "nuxt generate",
     "start": "nuxt start",


### PR DESCRIPTION
## 背景

PR #16 merge 之后，本地 `npm run build:docker` 验证发现 build 失败，根因是 Node 22 + 老 webpack 4 项目的 OpenSSL 兼容问题 + build 脚本里的多余 tsc + .dockerignore 误排除 jsconfig.json。三个 fix 已经通过 cherry-pick 直接合入 main（commit `00ad0cc`），本 PR 是事后补一个 PR 记录用。

> ⚠️ 这个 PR 的 diff 等价于 main 上 `00ad0cc` 的内容。GitHub 可能显示"already contains the changes"，但 PR 记录本身保留下来供 review。

## 改动

**1. `package.json` build 脚本加 OpenSSL legacy provider**

- nuxt.config.ts 是 .ts，package.json build 脚本里多余 tsc nuxt.config.ts
  会触发 node_modules 里的类型错误（@types/sass-loader / vue jsx）。Nuxt
  自带的 typescript-build 链已处理 TS 配置，不需要单独 tsc。

- Node 17+ 默认 OpenSSL 3 + webpack 4 用的 MD4 hash 不兼容，
  需要 `NODE_OPTIONS=--openssl-legacy-provider`。
  改后：`"build": "cross-env NODE_OPTIONS=--openssl-legacy-provider nuxt build"`

**2. `Dockerfile` builder stage 加 ENV**

- `ENV NODE_OPTIONS=--openssl-legacy-provider` 防止构建期子进程报 `ERR_OSSL_EVP_UNSUPPORTED`

**3. `deploy.sh` 同步加**

- `cmd_install` 和 `cmd_start` 都加 `NODE_OPTIONS=--openssl-legacy-provider`
- 透传到 `node node_modules/nuxt/bin/nuxt.js start` 启动

**4. `.dockerignore` 修复**

- 误排除 `jsconfig.json`（从 ladis-admin 抄过来，但 ladisSite 是有这个文件的）
- builder 镜像里没该文件 → runner stage `COPY .../jsconfig.json` 失败
- 删除该行

## 验证

本地 colima + Node 22.20.0：
- ✅ `npm run build` exit 0，产出 `.nuxt/{server.js, dist/server, dist/client, server.manifest.json}`
- ✅ `npm run build:docker` → `Successfully built d940b1d68af0`
- ✅ `docker run ladissite:latest` → 监听 :80，HTTP 200/401（sitemap 路由走代理预期）

## 关联

- 关联 PR：#16（多形态部署 + Docker 化 + 文档）
- 关联 memory：Node 17+ + 老 webpack 4 项目跑 build 报 `ERR_OSSL_EVP_UNSUPPORTED` 的解法